### PR TITLE
Split REST API reference into its own docs page

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,137 @@
+# REST API (Wired Detector only)
+
+The wired detector runs an HTTP server on port **8080** (configurable via `CONFIG_BATEAR_HTTP_PORT`) that exposes device info, detection status, OTA firmware updates, NVS configuration, and reboot.
+
+## Endpoints
+
+| Method | Path | Auth | Description |
+|:---|:---|:---|:---|
+| `GET` | `/api/info` | No | Device metadata (version, uptime, free heap, partition) |
+| `GET` | `/api/status` | No | Current detection state (drone_detected, confidence, rms_db) |
+| `GET` | `/api/recordings` | No | List captured WAV files (TF recorder only). |
+| `GET` | `/api/recordings/storage` | No | TF storage stats (mounted, used/free MiB, drops). |
+| `GET` | `/api/recordings/<file>` | No | Stream a specific WAV (chunked, `audio/wav`). |
+| `DELETE` | `/api/recordings/<file>` | Bearer | Delete a specific WAV (TF recorder only). |
+| `POST` | `/api/ota` | Bearer | Upload firmware binary for OTA update |
+| `POST` | `/api/config` | Bearer | Update NVS config keys (JSON body) |
+| `POST` | `/api/reboot` | Bearer | Reboot the device |
+
+## Authentication
+
+POST endpoints optionally require a Bearer token. Set it via:
+
+- **Kconfig**: `CONFIG_BATEAR_HTTP_AUTH_TOKEN`
+- **NVS**: `set http_token MyS3cretToken` via serial console
+- **API**: `POST /api/config` with `{"http_token":"newtoken"}`
+
+If the token is empty (default), POST endpoints are accessible without authentication.
+
+Include the token in requests:
+
+```bash
+curl -H "Authorization: Bearer MyS3cretToken" -X POST http://<ip>:8080/api/reboot
+```
+
+## GET /api/info
+
+Returns device metadata:
+
+```json
+{
+  "app_name": "batear",
+  "version": "v1.2.0",
+  "idf_version": "v6.0",
+  "compile_date": "Apr  7 2026 12:00:00",
+  "partition": "ota_0",
+  "free_heap": 245760,
+  "uptime_s": 3600
+}
+```
+
+## GET /api/status
+
+Returns the latest detection state:
+
+```json
+{
+  "drone_detected": true,
+  "detector_id": 1,
+  "rms_db": 45,
+  "f0_bin": 12,
+  "confidence": 0.8500,
+  "timestamp": 3600
+}
+```
+
+## POST /api/ota
+
+Upload a firmware binary to perform an over-the-air update. The device uses a two-OTA-partition layout with automatic rollback protection.
+
+```bash
+curl -X POST --data-binary @firmware.bin \
+  -H "Authorization: Bearer MyS3cretToken" \
+  http://<ip>:8080/api/ota
+```
+
+Response:
+
+```json
+{"status":"ok","bytes":1234567,"message":"rebooting in 1s"}
+```
+
+The device reboots after 1 second. On next boot, the new firmware calls `esp_ota_mark_app_valid_cancel_rollback()` to confirm the update. If the new firmware crashes before reaching that point, the bootloader automatically rolls back to the previous version.
+
+## POST /api/config
+
+Update NVS keys using a flat JSON object. The same keys available via the serial console are supported:
+
+```bash
+curl -X POST -H "Content-Type: application/json" \
+  -H "Authorization: Bearer MyS3cretToken" \
+  -d '{"mqtt_url":"mqtt://192.168.1.100:1883","eth_ip":"192.168.1.50"}' \
+  http://<ip>:8080/api/config
+```
+
+Response:
+
+```json
+{"status":"ok","keys_written":2,"note":"reboot to apply"}
+```
+
+Valid keys: `mqtt_url`, `mqtt_user`, `mqtt_pass`, `device_id`, `eth_ip`, `eth_gw`, `eth_mask`, `eth_dns`, `http_token`, `ntp_server`.
+
+!!! warning
+    Config changes take effect after reboot. Use `POST /api/reboot` or the serial console `reboot` command.
+
+## POST /api/reboot
+
+Reboots the device after responding:
+
+```bash
+curl -X POST -H "Authorization: Bearer MyS3cretToken" http://<ip>:8080/api/reboot
+```
+
+```json
+{"status":"ok","message":"rebooting in 1s"}
+```
+
+## Recordings endpoints
+
+```bash
+# List all recordings
+curl http://<ip>:8080/api/recordings
+
+# Storage stats
+curl http://<ip>:8080/api/recordings/storage
+
+# Download one
+curl -o sample.wav http://<ip>:8080/api/recordings/20260501-073000_00012_alarm.wav
+
+# Delete one (Bearer required)
+curl -X DELETE -H "Authorization: Bearer MyS3cretToken" \
+  http://<ip>:8080/api/recordings/20260501-073000_00012_alarm.wav
+```
+
+`<file>` whitelist: `[A-Za-z0-9_.-]+`, no leading dot, no `..`. Returns `503` if the SD card isn't mounted, `400` on a bad name, `404` if missing.
+
+See [TF Card Audio Recording](configuration.md#tf-card-audio-recording-wired-detector) for file format, triggers, and storage semantics.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -373,120 +373,7 @@ All entities are grouped under a single HA device: **Batear Wired Detector &lt;i
 
 ## REST API (Wired Detector only)
 
-The wired detector runs an HTTP server on port **8080** (configurable via `CONFIG_BATEAR_HTTP_PORT`) that exposes device info, detection status, OTA firmware updates, NVS configuration, and reboot.
-
-### Endpoints
-
-| Method | Path | Auth | Description |
-|:---|:---|:---|:---|
-| `GET` | `/api/info` | No | Device metadata (version, uptime, free heap, partition) |
-| `GET` | `/api/status` | No | Current detection state (drone_detected, confidence, rms_db) |
-| `GET` | `/api/recordings` | No | List captured WAV files (TF recorder only). |
-| `GET` | `/api/recordings/storage` | No | TF storage stats (mounted, used/free MiB, drops). |
-| `GET` | `/api/recordings/<file>` | No | Stream a specific WAV (chunked, `audio/wav`). |
-| `DELETE` | `/api/recordings/<file>` | Bearer | Delete a specific WAV (TF recorder only). |
-| `POST` | `/api/ota` | Bearer | Upload firmware binary for OTA update |
-| `POST` | `/api/config` | Bearer | Update NVS config keys (JSON body) |
-| `POST` | `/api/reboot` | Bearer | Reboot the device |
-
-### Authentication
-
-POST endpoints optionally require a Bearer token. Set it via:
-
-- **Kconfig**: `CONFIG_BATEAR_HTTP_AUTH_TOKEN`
-- **NVS**: `set http_token MyS3cretToken` via serial console
-- **API**: `POST /api/config` with `{"http_token":"newtoken"}`
-
-If the token is empty (default), POST endpoints are accessible without authentication.
-
-Include the token in requests:
-
-```bash
-curl -H "Authorization: Bearer MyS3cretToken" -X POST http://<ip>:8080/api/reboot
-```
-
-### GET /api/info
-
-Returns device metadata:
-
-```json
-{
-  "app_name": "batear",
-  "version": "v1.2.0",
-  "idf_version": "v6.0",
-  "compile_date": "Apr  7 2026 12:00:00",
-  "partition": "ota_0",
-  "free_heap": 245760,
-  "uptime_s": 3600
-}
-```
-
-### GET /api/status
-
-Returns the latest detection state:
-
-```json
-{
-  "drone_detected": true,
-  "detector_id": 1,
-  "rms_db": 45,
-  "f0_bin": 12,
-  "confidence": 0.8500,
-  "timestamp": 3600
-}
-```
-
-### POST /api/ota
-
-Upload a firmware binary to perform an over-the-air update. The device uses a two-OTA-partition layout with automatic rollback protection.
-
-```bash
-curl -X POST --data-binary @firmware.bin \
-  -H "Authorization: Bearer MyS3cretToken" \
-  http://<ip>:8080/api/ota
-```
-
-Response:
-
-```json
-{"status":"ok","bytes":1234567,"message":"rebooting in 1s"}
-```
-
-The device reboots after 1 second. On next boot, the new firmware calls `esp_ota_mark_app_valid_cancel_rollback()` to confirm the update. If the new firmware crashes before reaching that point, the bootloader automatically rolls back to the previous version.
-
-### POST /api/config
-
-Update NVS keys using a flat JSON object. The same keys available via the serial console are supported:
-
-```bash
-curl -X POST -H "Content-Type: application/json" \
-  -H "Authorization: Bearer MyS3cretToken" \
-  -d '{"mqtt_url":"mqtt://192.168.1.100:1883","eth_ip":"192.168.1.50"}' \
-  http://<ip>:8080/api/config
-```
-
-Response:
-
-```json
-{"status":"ok","keys_written":2,"note":"reboot to apply"}
-```
-
-Valid keys: `mqtt_url`, `mqtt_user`, `mqtt_pass`, `device_id`, `eth_ip`, `eth_gw`, `eth_mask`, `eth_dns`, `http_token`, `ntp_server`.
-
-!!! warning
-    Config changes take effect after reboot. Use `POST /api/reboot` or the serial console `reboot` command.
-
-### POST /api/reboot
-
-Reboots the device after responding:
-
-```bash
-curl -X POST -H "Authorization: Bearer MyS3cretToken" http://<ip>:8080/api/reboot
-```
-
-```json
-{"status":"ok","message":"rebooting in 1s"}
-```
+The wired detector exposes an HTTP server for device info, detection status, OTA firmware updates, NVS configuration, reboot, and TF-card recording management. See the dedicated [REST API reference](api.md) for endpoints, authentication, and example requests.
 
 ## TF Card Audio Recording (Wired Detector)
 
@@ -514,22 +401,7 @@ The WAV header `data_size` field is rewritten and `fsync()`'d every 10 s during 
 
 ### REST endpoints
 
-```bash
-# List all recordings
-curl http://<ip>:8080/api/recordings
-
-# Storage stats
-curl http://<ip>:8080/api/recordings/storage
-
-# Download one
-curl -o sample.wav http://<ip>:8080/api/recordings/20260501-073000_00012_alarm.wav
-
-# Delete one (Bearer required)
-curl -X DELETE -H "Authorization: Bearer MyS3cretToken" \
-  http://<ip>:8080/api/recordings/20260501-073000_00012_alarm.wav
-```
-
-`<file>` whitelist: `[A-Za-z0-9_.-]+`, no leading dot, no `..`. Returns `503` if the SD card isn't mounted, `400` on a bad name, `404` if missing.
+Recordings are listed, streamed, and deleted over HTTP. See [REST API → Recordings endpoints](api.md#recordings-endpoints) for curl examples and the filename whitelist.
 
 ### Storage management
 

--- a/docs/hardware.md
+++ b/docs/hardware.md
@@ -78,7 +78,7 @@ The wired detector connects directly to your network via Ethernet (RJ45). If you
     By default the wired detector uses DHCP. For fixed installations you can assign a static IP via the [serial console](configuration.md#serial-console) (`set eth_ip 192.168.1.50`) or at build time in `sdkconfig.wired_detector`. See [Configuration → Ethernet static IP](configuration.md#wired-detector-config) for details.
 
 !!! tip "OTA firmware updates"
-    The wired detector includes a built-in REST API (port 8080) that supports over-the-air firmware updates with automatic rollback. Upload a new binary with `curl -X POST --data-binary @firmware.bin http://<ip>:8080/api/ota`. See [Configuration → REST API](configuration.md#rest-api-wired-detector-only) for all endpoints.
+    The wired detector includes a built-in REST API (port 8080) that supports over-the-air firmware updates with automatic rollback. Upload a new binary with `curl -X POST --data-binary @firmware.bin http://<ip>:8080/api/ota`. See the [REST API reference](api.md) for all endpoints.
 
 ## Gateway
 

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -39,6 +39,6 @@ The gateway decrypts the LoRa packet and pushes a `MqttEvent_t` into a FreeRTOS 
 
 The wired detector's EthMqttTask receives `DroneEvent_t` items directly from AudioTask via a FreeRTOS queue and publishes them as JSON over MQTT. No gateway is needed — the detector connects directly to the MQTT broker over Ethernet (optionally via PoE for single-cable deployment). The network interface supports both DHCP (default) and static IP — see [Configuration](configuration.md#wired-detector-config) for setup.
 
-The wired detector also exposes a **REST API** on port 8080 for remote management: device info, detection status, NVS configuration updates, and **OTA firmware updates** — upload a new binary via `POST /api/ota` and the device reboots with automatic rollback protection. See [Configuration → REST API](configuration.md#rest-api-wired-detector-only) for endpoint reference.
+The wired detector also exposes a **REST API** on port 8080 for remote management: device info, detection status, NVS configuration updates, and **OTA firmware updates** — upload a new binary via `POST /api/ota` and the device reboots with automatic rollback protection. See the [REST API reference](api.md) for endpoint reference.
 
 Home Assistant discovers both device types automatically via MQTT Discovery — no manual YAML needed. See [Configuration → MQTT / Home Assistant](configuration.md#mqtt-home-assistant-integration) for topics, payloads, and setup.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -78,5 +78,6 @@ nav:
   - Reference:
       - Hardware: hardware.md
       - Calibration: calibration.md
+      - REST API: api.md
       - Adding a Board: adding-boards.md
   - Contributing: contributing.md


### PR DESCRIPTION
## Summary

- Extract the REST API section out of `docs/configuration.md` into a new dedicated `docs/api.md` under the Reference nav group, so the wired detector's HTTP surface has a single canonical page.
- Also pull the TF recordings REST endpoints (the four `curl` examples + filename whitelist) into `api.md` — `configuration.md` now only covers TF file format, triggers, storage management, and hot-plug behaviour.
- Update cross-links in `hardware.md` and `how-it-works.md` from the old `configuration.md#rest-api-wired-detector-only` deep anchor to `api.md`.
- Add `REST API: api.md` under Reference in `mkdocs.yml`.

No behaviour / API / auth changes — pure docs refactor. `GET /api/recordings*` are still unauthenticated and `DELETE` still requires Bearer, matching the current implementation.

## Test plan

- [ ] \`mkdocs serve\` locally and confirm:
  - [ ] New "REST API" page renders under Reference
  - [ ] Links from Hardware and How It Works pages land on `api.md`
  - [ ] `configuration.md` → `api.md#recordings-endpoints` jump works
  - [ ] `api.md` → `configuration.md#tf-card-audio-recording-wired-detector` back-link works
- [ ] CI docs build passes

Made with [Cursor](https://cursor.com)